### PR TITLE
chore(Release): Semantic Release Workflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,12 @@
       "@semantic-release/release-notes-generator",
       "@semantic-release/npm",
       "@semantic-release/github",
-      "@semantic-release/git",
+      [
+        "@semantic-release/git",
+        {
+          "message": "chore(release): ${nextRelease.version}\n\n${nextRelease.notes}"
+        }
+      ],
       "@semantic-release/changelog"
     ]
   }


### PR DESCRIPTION
Cloudflare was skipping the new build because of [Skip CI]